### PR TITLE
feat: added repo description, fail/test count

### DIFF
--- a/packages/api/scripts/populate.js
+++ b/packages/api/scripts/populate.js
@@ -59,7 +59,8 @@ const buildInfoTemplate = {
     matrix: '{Node: 11}',
     ref: 'branch/master'
   },
-  name: repo
+  name: repo,
+  description: 'A repository that is a repository... more description'
 };
 
 fs.readdir(directory, function (err, files) {
@@ -93,6 +94,7 @@ fs.readdir(directory, function (err, files) {
       buildInfo.repoId = firebaseEncode(buildInfo.organization + '/' + buildInfo.name);
       buildInfo.repoURL = 'http://github.com/' + buildInfo.organization + '/' + buildInfo.name;
     }
+    buildInfo.description = 'Description for the repository of ' + decodeURIComponent(buildInfo.repoId);
 
     addBuild(testCasesUse, buildInfo, client, repositoryCollection);
   });

--- a/packages/api/src/add-build.js
+++ b/packages/api/src/add-build.js
@@ -18,8 +18,8 @@
 * and builds
 * returns analytics object and adds such data to database
 */
+const { Firestore } = require('@google-cloud/firestore');
 const { buildPassingPercent, TestCaseAnalytics } = require('../lib/analytics.js');
-const Firestore = require('@google-cloud/firestore');
 
 function listifySnapshot (snapshot) {
   const results = [];
@@ -61,6 +61,7 @@ async function addBuild (testCases, buildInfo, client, collectionName = 'reposit
   repoUpdate.url = buildInfo.url;
   repoUpdate.repoId = decodeURIComponent(buildInfo.repoId);
   repoUpdate.name = buildInfo.name;
+  repoUpdate.description = buildInfo.description;
   repoUpdate.lower = {
     repoId: decodeURIComponent(buildInfo.repoId).toLowerCase(),
     name: buildInfo.name.toLowerCase(),
@@ -138,6 +139,8 @@ async function addBuild (testCases, buildInfo, client, collectionName = 'reposit
   // For the Builds
   await dbRepo.collection('builds').doc(buildInfo.buildId).set({
     percentpassing: buildPassingPercent(successes, failures),
+    passcount: successes.length,
+    failcount: Object.keys(failures).length,
     environment: buildInfo.environment,
     timestamp: buildInfo.timestamp,
     tests: alltests,

--- a/packages/api/src/post-build.js
+++ b/packages/api/src/post-build.js
@@ -57,7 +57,8 @@ class PostBuildHandler {
       environment: this.parseEnvironment(metadata),
       buildId: firebaseEncode(metadata.github.run_id),
       sha: metadata.github.sha,
-      name: metadata.github.event.repository.name
+      name: metadata.github.event.repository.name,
+      description: metadata.github.event.repository.description
     };
 
     // validate data

--- a/packages/api/test/addbuild-getbuild.js
+++ b/packages/api/test/addbuild-getbuild.js
@@ -44,7 +44,8 @@ const buildInfo = [
       new TestCaseRun('not ok', 2, 'a/2'),
       new TestCaseRun('ok', 3, 'a/3'),
       new TestCaseRun('not ok', 4, 'a/4')
-    ]
+    ],
+    description: 'nodejs repository'
   },
   {
     repoId: encodeURIComponent('nodejs/node'),
@@ -63,7 +64,8 @@ const buildInfo = [
     testCases: [
       new TestCaseRun('ok', 1, 'a/1'),
       new TestCaseRun('ok', 2, 'a/2') // this test is now passing
-    ]
+    ],
+    description: 'nodejs repository'
   },
   {
     repoId: encodeURIComponent('nodejs/node'),
@@ -82,7 +84,8 @@ const buildInfo = [
     testCases: [
       new TestCaseRun('not ok', 1, 'a/5'),
       new TestCaseRun('not ok', 2, 'a/2') // this test is now passing
-    ]
+    ],
+    description: 'nodejs repository'
   }
 ];
 
@@ -99,10 +102,13 @@ describe('Add-Build', () => {
       const organization = await client.collection(global.headCollection).doc(buildInfo[0].repoId).get();
       assert.strictEqual(organization.data().organization, buildInfo[0].organization);
       assert.strictEqual(organization.data().url, buildInfo[0].url);
+      assert.strictEqual(organization.data().description, buildInfo[0].description);
 
       // ensure builds were uploaded correctly
       const builds = await client.collection(global.headCollection).doc(buildInfo[0].repoId).collection('builds').doc(buildInfo[0].buildId).get();
       assert.strictEqual(builds.data().percentpassing, 0.5);
+      assert.strictEqual(builds.data().passcount, 2);
+      assert.strictEqual(builds.data().failcount, 2);
       assert.deepStrictEqual(builds.data().environment, buildInfo[0].environment);
     });
 
@@ -112,10 +118,13 @@ describe('Add-Build', () => {
       // ensure repository was initialized
       const organization = await client.collection(global.headCollection).doc(buildInfo[1].repoId).get();
       assert.strictEqual(organization.data().url, buildInfo[1].url);
+      assert.strictEqual(organization.data().description, buildInfo[1].description);
 
       // ensure builds were uploaded correctly
       const builds = await client.collection(global.headCollection).doc(buildInfo[1].repoId).collection('builds').doc(buildInfo[1].buildId).get();
       assert.strictEqual(builds.data().percentpassing, 1.0);
+      assert.strictEqual(builds.data().passcount, 2);
+      assert.strictEqual(builds.data().failcount, 0);
       assert.deepStrictEqual(builds.data().environment, buildInfo[1].environment);
     });
 
@@ -233,7 +242,7 @@ describe('Add-Build', () => {
       assert.strictEqual(ansObj[0].percentpassing, 0);
       assert.strictEqual(ansObj[0].tests.length, 2);
 
-      const solMeta = { name: 'node', repoId: 'nodejs/node', organization: 'nodejs', numfails: 2, flaky: 0, numtestcases: 2, lower: { name: 'node', repoId: 'nodejs/node', organization: 'nodejs' }, environments: { matrix: [{ 'node-version': '12.0' }], os: ['linux-apple', 'linux-banana'], tag: ['abc', 'xyz'], ref: ['master'] }, url: 'https://github.com/nodejs/node' };
+      const solMeta = { name: 'node', repoId: 'nodejs/node', description: 'nodejs repository', organization: 'nodejs', numfails: 2, flaky: 0, numtestcases: 2, lower: { name: 'node', repoId: 'nodejs/node', organization: 'nodejs' }, environments: { matrix: [{ 'node-version': '12.0' }], os: ['linux-apple', 'linux-banana'], tag: ['abc', 'xyz'], ref: ['master'] }, url: 'https://github.com/nodejs/node' };
 
       assert.deepStrictEqual(JSON.parse(respText).metadata, solMeta);
     });

--- a/packages/api/test/analytics-test.js
+++ b/packages/api/test/analytics-test.js
@@ -26,13 +26,13 @@ const buildInfo = {
   name: 'repo',
   sha: '123',
   url: 'https://github.com/nodejs/WRONG', // URL starts off wrong
+  description: 'Repository description',
   environment: {
     os: 'linux-apple',
     matrix: { 'node-version': '12.0' },
     ref: 'master',
     tag: 'abc'
   }
-
 };
 // testcases a, b, c, d
 // 0 is one recent failure


### PR DESCRIPTION
- Added a repository description field
- For a particular build, store a count of the number of failures and successes in that build `passcount` and `failcount`


The [org page json](https://gist.github.com/StuartRucker/411a1094895a70dd29937bf06f8f402a) and [repo page json](https://gist.github.com/StuartRucker/eb19eac0149debc7542d9444f2c71767) can be found at the links in this sentence.