### PR TITLE
feat: exports data as csv

### DIFF
--- a/packages/api/scripts/populate.js
+++ b/packages/api/scripts/populate.js
@@ -56,7 +56,7 @@ const buildInfoTemplate = {
   environment: {
     os: 'Linux',
     tag: 'NA',
-    matrix: '{Node: 11}',
+    matrix: JSON.stringify({ Node: 11 }),
     ref: 'branch/master'
   },
   name: repo,
@@ -89,7 +89,7 @@ fs.readdir(directory, function (err, files) {
     buildInfo.buildId = Math.random().toString(36).substring(2, 15);
     buildInfo.environment.os = (Math.random() > 0.5) ? 'Linux' : 'Windows';
     buildInfo.environment.ref = (Math.random() > 0.66) ? 'ref/master' : ((Math.random() > 0.5) ? 'ref/a' : 'ref/b');
-    buildInfo.environment.matrix = (Math.random() > 0.5) ? '{Node:10}}' : '{Node:11}';
+    buildInfo.environment.matrix = (Math.random() > 0.5) ? JSON.stringify({ Node: 11 }) : JSON.stringify({ Node: 10 });
 
     // put half of tests in default repo/org
     if (Math.random() > 0.5) {

--- a/packages/api/server.js
+++ b/packages/api/server.js
@@ -25,6 +25,7 @@ const PostBuildHandler = require('./src/post-build.js');
 const GetRepoHandler = require('./src/get-repo.js');
 const GetOrgHandler = require('./src/get-org.js');
 const GetTestHandler = require('./src/get-test.js');
+const GetExportHandler = require('./src/get-export.js');
 const client = require('./src/firestore.js');
 
 const { FirestoreStore } = require('@google-cloud/connect-firestore');
@@ -140,9 +141,11 @@ const getOrgHandler = new GetOrgHandler(app, client);
 getOrgHandler.listen();
 const getTestHandler = new GetTestHandler(app, client);
 getTestHandler.listen();
+const getExportHandler = new GetExportHandler(app, client);
+getExportHandler.listen();
 
 const port = process.env.PORT ? Number(process.env.PORT) : 3000;
-const host = '0.0.0.0';
+const host = '127.0.0.1';
 const server = app.listen(port, host, () => console.log(`Example app listening at http://localhost:${port}`));
 
 module.exports = server;

--- a/packages/api/server.js
+++ b/packages/api/server.js
@@ -145,7 +145,7 @@ const getExportHandler = new GetExportHandler(app, client);
 getExportHandler.listen();
 
 const port = process.env.PORT ? Number(process.env.PORT) : 3000;
-const host = '127.0.0.1';
+const host = '0.0.0.0';
 const server = app.listen(port, host, () => console.log(`Example app listening at http://localhost:${port}`));
 
 module.exports = server;

--- a/packages/api/src/add-build.js
+++ b/packages/api/src/add-build.js
@@ -46,7 +46,6 @@ async function addBuild (testCases, buildInfo, client, collectionName = 'reposit
   // if this build has already been posted, skip
   const thisBuildExists = await dbRepo.collection('builds').doc(buildInfo.buildId).get();
   if (thisBuildExists.exists) {
-    console.log('skipping because build already exists');
     return;
   }
 

--- a/packages/api/src/get-export.js
+++ b/packages/api/src/get-export.js
@@ -125,7 +125,7 @@ class GetExportHandler {
         for (const key in builds) {
           stringSolution.push(builds[key].toString(allMatrixList));
         }
-        // res.set({ 'Content-Disposition': 'attachment; filename="' + decodeURIComponent(repoid) + '.csv"' });
+        res.set({ 'Content-Disposition': 'attachment; filename="' + decodeURIComponent(repoid) + '.csv"' });
         res.send(stringSolution.join('\n'));
       } catch (err) {
         handleError(res, err);

--- a/packages/api/src/get-export.js
+++ b/packages/api/src/get-export.js
@@ -36,7 +36,7 @@ class CsvRow {
   toString (allMatrixList) {
     const infoAsList = [this.buildId, this.timestamp.toString(), this.environment.ref, this.environment.os, this.environment.tag];
     const parsedMatrix = this.environment.matrix;
-    for (const key in allMatrixList) {
+    for (const key of allMatrixList) {
       if (key in parsedMatrix) {
         infoAsList.push(parsedMatrix[key]);
       } else {
@@ -120,12 +120,12 @@ class GetExportHandler {
         }
 
         const allMatrixList = Array.from(allMatrix);
-
-        const stringSolution = [CsvRow.getHeader(testNamesInOrder, allMatrixList.map(x => 'Matrix.' + x))];
+        const allMatrixListPrepended = allMatrixList.map(x => 'Matrix.' + x);
+        const stringSolution = [CsvRow.getHeader(testNamesInOrder, allMatrixListPrepended)];
         for (const key in builds) {
           stringSolution.push(builds[key].toString(allMatrixList));
         }
-        res.set({ 'Content-Disposition': 'attachment; filename="' + decodeURIComponent(repoid) + '.csv"' });
+        // res.set({ 'Content-Disposition': 'attachment; filename="' + decodeURIComponent(repoid) + '.csv"' });
         res.send(stringSolution.join('\n'));
       } catch (err) {
         handleError(res, err);

--- a/packages/api/src/get-export.js
+++ b/packages/api/src/get-export.js
@@ -23,15 +23,15 @@ class CsvRow {
   constructor (buildId, environment, timestamp, totalTestCount, testNameToId) {
     this.buildId = buildId;
     this.environment = environment;
-    this.testResults = new Array(totalTestCount).fill(-1);  //-1 denotes test did not run
+    this.testResults = new Array(totalTestCount).fill(-1); // -1 denotes test did not run
     this.testNameToId = testNameToId;
     this.timestamp = timestamp.toDate();
   }
 
   setTestResult (testName, status) {
-    if(testName in this.testNameToId){
+    if (testName in this.testNameToId) {
       const testIndex = this.testNameToId[testName];
-      this.testResults[testIndex] = (status === 'OK') ? 1 : 0; //1 = test pass, 0 = test fail
+      this.testResults[testIndex] = (status === 'OK') ? 1 : 0; // 1 = test pass, 0 = test fail
     }
   }
 

--- a/packages/api/src/get-export.js
+++ b/packages/api/src/get-export.js
@@ -1,0 +1,111 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// class to receive POSTS with build information
+
+const firebaseEncode = require('../lib/firebase-encode');
+const { handleError } = require('../lib/errors');
+const client = require('./firestore.js');
+
+// 1 = pass, 0 = fail, -1 = not run
+class CsvRow {
+  constructor (buildId, environment, timestamp, totalTestCount, testNameToId) {
+    this.buildId = buildId;
+    this.environment = environment;
+    this.testResults = new Array(totalTestCount).fill(-1);
+    this.testNameToId = testNameToId;
+    this.timestamp = timestamp.toDate();
+  }
+
+  setTestResult (testName, status) {
+    const testIndex = this.testNameToId[testName];
+    this.testResults[testIndex] = (status === 'OK') ? 1 : 0;
+  }
+
+  toString () {
+    const infoAsList = [this.buildId, this.timestamp.toString(), this.environment.ref, this.environment.os, this.environment.tag, this.environment.matrix];
+    return infoAsList.concat(this.testResults).join(', ');
+  }
+
+  static getHeader (testNamesInOrder) {
+    return ['Build Id', 'Timestamp', 'Ref', 'Os', 'Tag', 'Matrix'].concat(testNamesInOrder).join(', ');
+  }
+}
+
+class GetExportHandler {
+  constructor (app, client) {
+    this.app = app;
+    this.client = client;
+  }
+
+  async getTest (client, repoid, testname) {
+    const getOperations = [];
+
+    const allRuns = await client.collection(global.headCollection).doc(repoid).collection('tests').doc(testname).collection('runs').get();
+    allRuns.forEach(run => {
+      getOperations.push(run.ref.get());
+    });
+
+    return Promise.all(getOperations);
+  }
+
+  listen () {
+    this.app.get('/api/repo/:orgname/:reponame/csv', async (req, res, next) => {
+      try {
+        const repoid = firebaseEncode(req.params.orgname + '/' + req.params.reponame);
+
+        const getRunOperations = [];
+        const testNameToId = {};
+        const testNamesInOrder = [];
+        let testCount = 0;
+
+        const allTests = await this.client.collection(global.headCollection).doc(repoid).collection('tests').get();
+
+        allTests.forEach(test => {
+          getRunOperations.push(this.getTest(client, repoid, firebaseEncode(test.data().name)));
+
+          testNameToId[test.data().name] = testCount++;
+          testNamesInOrder.push(test.data().name);
+        });
+        const totalTestCount = testCount;
+
+        const awaitedTests = await Promise.all(getRunOperations);
+
+        // post process into csv
+        const builds = {};
+        for (let i = 0; i < totalTestCount; i++) {
+          const testname = testNamesInOrder[i];
+          const test = awaitedTests[i];
+          test.forEach(run => {
+            const runInfo = run.data();
+            if (!(runInfo.buildId in builds)) {
+              builds[runInfo.buildId] = new CsvRow(runInfo.buildId, runInfo.environment, runInfo.timestamp, totalTestCount, testNameToId);
+            }
+            builds[runInfo.buildId].setTestResult(testname, runInfo.status);
+          }); 
+        }
+
+        const stringSolution = [CsvRow.getHeader(testNamesInOrder)];
+        for (const key in builds) {
+          stringSolution.push(builds[key].toString());
+        }
+        res.send(stringSolution.join('<br>'));
+      } catch (err) {
+        handleError(res, err);
+      }
+    });
+  }
+}
+
+module.exports = GetExportHandler;

--- a/packages/api/src/get-export.js
+++ b/packages/api/src/get-export.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// class to receive POSTS with build information
+// class to export build and test data as csv
 
 const firebaseEncode = require('../lib/firebase-encode');
 const { ResourceNotFoundError, handleError } = require('../lib/errors');
@@ -23,14 +23,16 @@ class CsvRow {
   constructor (buildId, environment, timestamp, totalTestCount, testNameToId) {
     this.buildId = buildId;
     this.environment = environment;
-    this.testResults = new Array(totalTestCount).fill(-1);
+    this.testResults = new Array(totalTestCount).fill(-1);  //-1 denotes test did not run
     this.testNameToId = testNameToId;
     this.timestamp = timestamp.toDate();
   }
 
   setTestResult (testName, status) {
-    const testIndex = this.testNameToId[testName];
-    this.testResults[testIndex] = (status === 'OK') ? 1 : 0;
+    if(testName in this.testNameToId){
+      const testIndex = this.testNameToId[testName];
+      this.testResults[testIndex] = (status === 'OK') ? 1 : 0; //1 = test pass, 0 = test fail
+    }
   }
 
   toString (allMatrixList) {

--- a/packages/api/test/addbuild-getbuild.js
+++ b/packages/api/test/addbuild-getbuild.js
@@ -384,7 +384,7 @@ describe('Add-Build', () => {
         url: 'https://github.com/nodejs/node',
         environment: {
           os: 'linux-banana',
-          matrix: { 'node-version': '12.0', 'other, field': '12.0' }, // ensures comma isnt problematic
+          matrix: { 'node-version': '12.0', 'other field': '12.0' },
           ref: 'master',
           tag: 'xyz'
         },

--- a/packages/api/test/addbuild-getbuild.js
+++ b/packages/api/test/addbuild-getbuild.js
@@ -371,7 +371,20 @@ describe('Add-Build', () => {
       const resp = await fetch('http://localhost:3000/api/repo/nodejs/node/csv');
 
       const respText = await resp.text();
-      assert.strictEqual(respText, SIMPLE_EXPORT);
+
+      const linesReal = respText.split(/\n/);
+      const linesExpected = SIMPLE_EXPORT.split(/\n/);
+      assert.strictEqual(linesReal.length, linesExpected.length);
+      for (let i = 0; i < linesReal.length; i++) {
+        const rowReal = linesReal[i].split(/\s,/);
+        const rowExpected = linesExpected[i].split(/\s,/);
+        assert.strictEqual(rowReal.length, rowExpected.length);
+        for (let k = 0; k < rowReal.length; k++) {
+          if (k !== 1) { // ignore timestamp
+            assert.strictEqual(rowReal[k], rowExpected[k]);
+          }
+        }
+      }
     });
 
     it('Can handle exports with tricky matrix parameter', async () => {
@@ -400,7 +413,22 @@ describe('Add-Build', () => {
       const resp = await fetch('http://localhost:3000/api/repo/nodejs/node/csv');
 
       const respText = await resp.text();
-      assert.strictEqual(respText, TRICKY_EXPORT);
+
+      const linesReal = respText.split(/\n/);
+      const linesExpected = TRICKY_EXPORT.split(/\n/);
+      assert.strictEqual(linesReal.length, linesExpected.length);
+      for (let i = 0; i < linesReal.length; i++) {
+        const rowReal = linesReal[i].split(/\s,/);
+        const rowExpected = linesExpected[i].split(/\s,/);
+        assert.strictEqual(rowReal.length, rowExpected.length);
+        for (let k = 0; k < rowReal.length; k++) {
+          if (k !== 1) { // ignore timestamp
+            assert.strictEqual(rowReal[k], rowExpected[k]);
+          }
+        }
+      }
+
+      // assert.strictEqual(respText, TRICKY_EXPORT);
     });
   });
 

--- a/packages/api/test/addbuild-getbuild.js
+++ b/packages/api/test/addbuild-getbuild.js
@@ -376,8 +376,8 @@ describe('Add-Build', () => {
       const linesExpected = SIMPLE_EXPORT.split(/\n/);
       assert.strictEqual(linesReal.length, linesExpected.length);
       for (let i = 0; i < linesReal.length; i++) {
-        const rowReal = linesReal[i].split(/\s,/);
-        const rowExpected = linesExpected[i].split(/\s,/);
+        const rowReal = linesReal[i].split(/,\s/);
+        const rowExpected = linesExpected[i].split(/,\s/);
         assert.strictEqual(rowReal.length, rowExpected.length);
         for (let k = 0; k < rowReal.length; k++) {
           if (k !== 1) { // ignore timestamp
@@ -418,8 +418,8 @@ describe('Add-Build', () => {
       const linesExpected = TRICKY_EXPORT.split(/\n/);
       assert.strictEqual(linesReal.length, linesExpected.length);
       for (let i = 0; i < linesReal.length; i++) {
-        const rowReal = linesReal[i].split(/\s,/);
-        const rowExpected = linesExpected[i].split(/\s,/);
+        const rowReal = linesReal[i].split(/,\s/);
+        const rowExpected = linesExpected[i].split(/,\s/);
         assert.strictEqual(rowReal.length, rowExpected.length);
         for (let k = 0; k < rowReal.length; k++) {
           if (k !== 1) { // ignore timestamp

--- a/packages/api/test/addbuild-getbuild.js
+++ b/packages/api/test/addbuild-getbuild.js
@@ -427,8 +427,6 @@ describe('Add-Build', () => {
           }
         }
       }
-
-      // assert.strictEqual(respText, TRICKY_EXPORT);
     });
   });
 

--- a/packages/api/test/res/simpleexport.csv
+++ b/packages/api/test/res/simpleexport.csv
@@ -1,0 +1,4 @@
+Build Id, Timestamp, Ref, Os, Tag, Matrix.node-version, a/1, a/2, a/3, a/4, a/5
+11111, Mon Jan 01 2001 00:00:00 GMT-0700 (Mountain Standard Time), master, linux-apple, abc, None, 1, 0, 1, 0, -1
+22222, Sat Jan 01 2000 00:00:00 GMT-0700 (Mountain Standard Time), master, linux-banana, xyz, None, 1, 1, -1, -1, -1
+33333, Tue Jan 01 2002 00:00:00 GMT-0700 (Mountain Standard Time), master, linux-banana, xyz, None, -1, 0, -1, -1, 0

--- a/packages/api/test/res/simpleexport.csv
+++ b/packages/api/test/res/simpleexport.csv
@@ -1,4 +1,4 @@
 Build Id, Timestamp, Ref, Os, Tag, Matrix.node-version, a/1, a/2, a/3, a/4, a/5
-11111, Mon Jan 01 2001 00:00:00 GMT-0700 (Mountain Standard Time), master, linux-apple, abc, None, 1, 0, 1, 0, -1
-22222, Sat Jan 01 2000 00:00:00 GMT-0700 (Mountain Standard Time), master, linux-banana, xyz, None, 1, 1, -1, -1, -1
-33333, Tue Jan 01 2002 00:00:00 GMT-0700 (Mountain Standard Time), master, linux-banana, xyz, None, -1, 0, -1, -1, 0
+11111, Mon Jan 01 2001 00:00:00 GMT-0700 (Mountain Standard Time), master, linux-apple, abc, 12.0, 1, 0, 1, 0, -1
+22222, Sat Jan 01 2000 00:00:00 GMT-0700 (Mountain Standard Time), master, linux-banana, xyz, 12.0, 1, 1, -1, -1, -1
+33333, Tue Jan 01 2002 00:00:00 GMT-0700 (Mountain Standard Time), master, linux-banana, xyz, 12.0, -1, 0, -1, -1, 0

--- a/packages/api/test/res/trickyexport.csv
+++ b/packages/api/test/res/trickyexport.csv
@@ -1,0 +1,5 @@
+Build Id, Timestamp, Ref, Os, Tag, Matrix.node-version, Matrix.other field, a/1, a/2, a/3, a/4, a/5
+11111, Mon Jan 01 2001 00:00:00 GMT-0700 (Mountain Standard Time), master, linux-apple, abc, None, None, 1, 0, 1, 0, -1
+22222, Sat Jan 01 2000 00:00:00 GMT-0700 (Mountain Standard Time), master, linux-banana, xyz, None, None, 1, 1, -1, -1, -1
+33333, Tue Jan 01 2002 00:00:00 GMT-0700 (Mountain Standard Time), master, linux-banana, xyz, None, None, -1, 0, -1, -1, 0
+44444, Thu Jan 01 2004 00:00:00 GMT-0700 (Mountain Standard Time), master, linux-banana, xyz, None, None, -1, 0, -1, -1, 0

--- a/packages/api/test/res/trickyexport.csv
+++ b/packages/api/test/res/trickyexport.csv
@@ -1,5 +1,5 @@
 Build Id, Timestamp, Ref, Os, Tag, Matrix.node-version, Matrix.other field, a/1, a/2, a/3, a/4, a/5
-11111, Mon Jan 01 2001 00:00:00 GMT-0700 (Mountain Standard Time), master, linux-apple, abc, None, None, 1, 0, 1, 0, -1
-22222, Sat Jan 01 2000 00:00:00 GMT-0700 (Mountain Standard Time), master, linux-banana, xyz, None, None, 1, 1, -1, -1, -1
-33333, Tue Jan 01 2002 00:00:00 GMT-0700 (Mountain Standard Time), master, linux-banana, xyz, None, None, -1, 0, -1, -1, 0
-44444, Thu Jan 01 2004 00:00:00 GMT-0700 (Mountain Standard Time), master, linux-banana, xyz, None, None, -1, 0, -1, -1, 0
+11111, Mon Jan 01 2001 00:00:00 GMT-0700 (Mountain Standard Time), master, linux-apple, abc, 12.0, None, 1, 0, 1, 0, -1
+22222, Sat Jan 01 2000 00:00:00 GMT-0700 (Mountain Standard Time), master, linux-banana, xyz, 12.0, None, 1, 1, -1, -1, -1
+33333, Tue Jan 01 2002 00:00:00 GMT-0700 (Mountain Standard Time), master, linux-banana, xyz, 12.0, None, -1, 0, -1, -1, 0
+44444, Thu Jan 01 2004 00:00:00 GMT-0700 (Mountain Standard Time), master, linux-banana, xyz, 12.0, 12.0, -1, 0, -1, -1, 0


### PR DESCRIPTION
Added `/api/repo/:org/:repo/csv` endpoint which downloads a csv file of all builds and tests. It processes all the matrix fields as there own columns, with "none" in them if a particular build did not have a value for that matrix key. 

See [Sample Export ](https://docs.google.com/spreadsheets/d/1ceRB_c0M7GHxN4AB6XZocslZgJT1hPJlUVjtF0Jxfx4/edit?usp=sharing)(with conditional formatting applied afterwards)

In the CSV, 1=pass, 0=fail, and -1= did not run

Small fix in populate script where previously invalid json was being posted

Note: The checking for equality between CSV files ignores the timestamp column since the test server is not on the same time zone.