### PR TITLE
fix: remove bad constructor calls

### DIFF
--- a/packages/api/lib/tap-parser.js
+++ b/packages/api/lib/tap-parser.js
@@ -39,7 +39,7 @@ function getTestCases (inputFilePath, fileName) {
     var dateMatch = outcome[i].match(dateRegex);
 
     if (tryMatch !== null) {
-      testCases.push(new TestCaseRun(tryMatch.groups.status, tryMatch.groups.casenumb, tryMatch.groups.message));
+      testCases.push(new TestCaseRun(tryMatch.groups.status, tryMatch.groups.message));
     }
 
     if (dateMatch !== null && determinedDate == null) {

--- a/packages/api/test/analytics-test.js
+++ b/packages/api/test/analytics-test.js
@@ -64,7 +64,7 @@ describe('Flaky-Analytics', () => {
     for (let i = 0; i < testCases.length; i++) {
       const testCaseObjs = [];
       for (let k = 0; k < testCases[i].length; k++) {
-        testCaseObjs.push(new TestCaseRun(testCases[i][k] ? 'ok' : 'not ok', k, k.toString()));
+        testCaseObjs.push(new TestCaseRun(testCases[i][k] ? 'ok' : 'not ok', k.toString()));
       }
       const updateObj = JSON.parse(JSON.stringify(buildInfo));
       updateObj.timestamp = new Date('01/01/202' + i.toString());


### PR DESCRIPTION
Just a tiny fix from a refactor I did last week.

Might have a small merge conflict with https://github.com/GoogleCloudPlatform/flaky-service/pull/263. Once that one is landed, this PR may be unnecessary but if it isn't then I will fix the conflict.