### PR TITLE
fix(api): "fixing" a test case should update the aggregate repo stats

### DIFF
--- a/packages/api/lib/deleter.js
+++ b/packages/api/lib/deleter.js
@@ -13,7 +13,8 @@
 
 // class to receive POSTS with build information
 
-const firebaseEncode = require('../lib/firebase-encode');
+const firebaseEncode = require('./firebase-encode');
+const { updateRepoStats } = require('../src/update-repo-stats');
 
 async function deleteRepo (repoId, client) {
   const deleteOperations = [];
@@ -35,23 +36,18 @@ async function deleteRepo (repoId, client) {
 
 // this does not delete the tests names stored in a list under a specific build. These names should not be used without first looking
 // in the test collection to verify that the test does indeed exist
-async function deleteTest (repoId, testname, client) {
-  console.info(JSON.stringify({
-    severity: 'INFO',
-    message: 'attempting to delete test case',
-    repo_id: repoId,
-    testname,
-    testnameEncoded: firebaseEncode(testname)
-  }));
+async function deleteTest (repoIdRaw, testname, client) {
+  const repoId = firebaseEncode(repoIdRaw);
   const deleteOperations = [];
-  const allRuns = await client.collection(global.headCollection).doc(firebaseEncode(repoId)).collection('queued').doc(firebaseEncode(testname)).collection('runs').get();
+  const allRuns = await client.collection(global.headCollection).doc(repoId).collection('queued').doc(firebaseEncode(testname)).collection('runs').get();
   allRuns.forEach(async (run) => {
     deleteOperations.push(run.ref);
   });
   for (const operation of deleteOperations) {
     await operation.delete();
   }
-  await client.collection(global.headCollection).doc(firebaseEncode(repoId)).collection('queued').doc(firebaseEncode(testname)).delete();
+  await client.collection(global.headCollection).doc(repoId).collection('queued').doc(firebaseEncode(testname)).delete();
+  await updateRepoStats(repoId, client);
 }
 
 module.exports = { deleteTest, deleteRepo };

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -5,7 +5,7 @@
   "description": "the api for the flaky.dev service",
   "main": "server.js",
   "scripts": {
-    "test": "c8 mocha --reporter=tap --timeout=50000 test/*.js test/unit/*.js | tee test.tap | tap-spec",
+    "test": "c8 --reporter=text --reporter=html mocha --reporter=tap --timeout=50000 test/*.js test/unit/*.js | tee test.tap | tap-spec",
     "posttest": "semistandard",
     "fix": "semistandard --fix"
   },

--- a/packages/api/src/add-build.js
+++ b/packages/api/src/add-build.js
@@ -250,9 +250,10 @@ async function updateRepoDoc (buildInfo, dbRepo) {
     repoUpdate['environments.' + prop] = Firestore.FieldValue.arrayUnion(buildInfo.environment[prop]);
   }
 
-  // The top level repository object tracks aggregate test runs from the last
+  // The top level repository object tracks aggregate test stats from the last
   // AGGREGATE_SIZE test runs:
-  // TODO: we should consider moving to calculating this daily.
+  // TODO: we should consider moving towards calculating this daily to save
+  // on read operations.
   const queuedTestLookup = await dbRepo
     .collection('queued')
     .orderBy('searchindex', 'desc')

--- a/packages/api/src/add-build.js
+++ b/packages/api/src/add-build.js
@@ -27,7 +27,6 @@ const AGGREGATE_SIZE = 25;
 const RESET_SUCCESS_COUNT = 15;
 const api = { addTestRun, addBuild, updateQueue, updateTest };
 
-// Main Functionalitkk
 /*
 * Adds a list of TestCaseRun objects to the database, described by the meta information in buildInfo
 *       Does not assume repository has been initializ
@@ -44,12 +43,9 @@ async function addBuild (testCases, buildInfo, client, collectionName) {
   buildInfo.buildIdReadable = buildInfo.buildId;
   buildInfo.buildId = uuidv4(); // buildId will always be UUID
 
-  const phaseOne = await Promise.all([updateAllTests(testCases, buildInfo, dbRepo), isMostRecentBuild(buildInfo, dbRepo)]);
-  // unpack results
-  const computedData = phaseOne[0];
-  const mostRecent = phaseOne[1];
+  const [computedData] = await Promise.all([updateAllTests(testCases, buildInfo, dbRepo), isMostRecentBuild(buildInfo, dbRepo)]);
 
-  await Promise.all([addBuildDoc(testCases, buildInfo, computedData, dbRepo), updateRepoDoc(buildInfo, mostRecent, dbRepo)]);
+  await Promise.all([addBuildDoc(testCases, buildInfo, computedData, dbRepo), updateRepoDoc(buildInfo, dbRepo)]);
 }
 
 async function updateAllTests (testCases, buildInfo, dbRepo) {
@@ -236,7 +232,7 @@ async function addBuildDoc (testCases, buildInfo, computedData, dbRepo) {
   });
 }
 
-async function updateRepoDoc (buildInfo, mostRecent, dbRepo) {
+async function updateRepoDoc (buildInfo, dbRepo) {
   const repoId = decodeURIComponent(buildInfo.repoId);
   const repoUpdate = {
     organization: buildInfo.organization,
@@ -275,13 +271,12 @@ async function updateRepoDoc (buildInfo, mostRecent, dbRepo) {
     return a;
   }, { flaky: 0, failing: 0 });
 
-  if (mostRecent) {
-    repoUpdate.flaky = results.flaky;
-    repoUpdate.numfails = results.failing;
-    repoUpdate.searchindex = results.failing * 10000 + results.flaky;
-    repoUpdate.numtestcases = queuedTestLookup.size;
-    repoUpdate.lastupdate = buildInfo.timestamp;
-  }
+  repoUpdate.flaky = results.flaky;
+  repoUpdate.numfails = results.failing;
+  repoUpdate.searchindex = results.failing * 10000 + results.flaky;
+  repoUpdate.numtestcases = queuedTestLookup.size;
+  repoUpdate.lastupdate = buildInfo.timestamp;
+
   await dbRepo.update(repoUpdate, { merge: true });
 }
 

--- a/packages/api/src/update-repo-stats.js
+++ b/packages/api/src/update-repo-stats.js
@@ -17,14 +17,13 @@ const AGGREGATE_SIZE = 25;
 /*
 * Updates the aggregate statistics for a given repository.
 *
-* @param repoId identifier of repository that requires its aggregate stat supdated.
+* @param repoId identifier of repository that requires its aggregate stats updated.
 */
 async function updateRepoStats (repoId, client) {
   const dbRepo = client.collection(global.headCollection).doc(repoId);
 
-  // The top level repository object tracks aggregate test runs from the last
+  // The top level repository object tracks aggregate test stats from the last
   // AGGREGATE_SIZE test runs:
-  // TODO: we should consider moving to calculating this daily.
   const queuedTestLookup = await dbRepo
     .collection('queued')
     .orderBy('searchindex', 'desc')

--- a/packages/api/src/update-repo-stats.js
+++ b/packages/api/src/update-repo-stats.js
@@ -18,6 +18,7 @@ const AGGREGATE_SIZE = 25;
 * Updates the aggregate statistics for a given repository.
 *
 * @param repoId identifier of repository that requires its aggregate stats updated.
+* @param client a firestore client instance.
 */
 async function updateRepoStats (repoId, client) {
   const dbRepo = client.collection(global.headCollection).doc(repoId);

--- a/packages/api/src/update-repo-stats.js
+++ b/packages/api/src/update-repo-stats.js
@@ -1,0 +1,58 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const AGGREGATE_SIZE = 25;
+
+/*
+* Updates the aggregate statistics for a given repository.
+*
+* @param repoId identifier of repository that requires its aggregate stat supdated.
+*/
+async function updateRepoStats (repoId, client) {
+  const dbRepo = client.collection(global.headCollection).doc(repoId);
+
+  // The top level repository object tracks aggregate test runs from the last
+  // AGGREGATE_SIZE test runs:
+  // TODO: we should consider moving to calculating this daily.
+  const queuedTestLookup = await dbRepo
+    .collection('queued')
+    .orderBy('searchindex', 'desc')
+    .orderBy('lastupdate', 'desc')
+    .offset(0)
+    .limit(AGGREGATE_SIZE)
+    .get();
+  const queuedTests = queuedTestLookup.docs.map(doc => doc.data());
+  const results = queuedTests.reduce((a, test) => {
+    if (!test.passed) {
+      a.failing++;
+    }
+    if (test.flaky) {
+      a.flaky++;
+    }
+    return a;
+  }, { flaky: 0, failing: 0 });
+
+  const repoUpdate = {
+    flaky: results.flaky,
+    numfails: results.failing,
+    searchindex: results.failing * 10000 + results.flaky,
+    numtestcases: queuedTestLookup.size
+  };
+
+  await dbRepo.update(repoUpdate, { merge: true });
+}
+
+module.exports = {
+  updateRepoStats
+};


### PR DESCRIPTION
We track aggregate test statistics on the top level repository document. We need to update these statistics when a test is "fixed", i.e., _deleted_.